### PR TITLE
Add base multi-VM Vagrant configuration

### DIFF
--- a/virtualbox/multi-vm-setup/Vagrantfile
+++ b/virtualbox/multi-vm-setup/Vagrantfile
@@ -1,0 +1,26 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  # Common configuration
+  config.vm.box = "ubuntu/focal64"
+
+  # Web Server VM
+  config.vm.define "web" do |web|
+    web.vm.hostname = "web-server"
+    web.vm.network "private_network", ip: "192.168.33.10"
+    web.vm.provider "virtualbox" do |vb|
+      vb.memory = "1024"
+      vb.cpus = 1
+    end
+  end
+  
+  # Database VM
+  config.vm.define "db" do |db|
+    db.vm.hostname = "db-server"
+    db.vm.network "private_network", ip: "192.168.33.11"
+      vb.memory = "2048"
+      vb.cpus = 2
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a base Vagrant configuration for a multi-VM environment with two virtual machines: a web server and a database server.
The code is written in Ruby.
The web server machine has 1 CPU.
The database server has 2 CPUs.

Closes #11 