### PR TITLE
Updated .gitignore to ignore Terraform state files and providers

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -13,3 +13,8 @@
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# Ignore Terraform state files and providers
+terraform.tfstate
+terraform.lock.hcl
+terraform/providers/

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -17,4 +17,10 @@ terraform.rc
 # Ignore Terraform state files and providers
 terraform.tfstate
 terraform.lock.hcl
-terraform/providers/
+
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*


### PR DESCRIPTION
The following files were added to ".gitignore" to exclude Terraform-related files from the repository:
- terraform.tfstate
- terraform.lock.hcl
- terraform/providers/

Closes #19 